### PR TITLE
fix: Move dart commands to devcontainer.json

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -35,7 +35,5 @@ RUN /home/${USERNAME}/.local/flutter/bin/flutter precache --web
 
 RUN chown -R ${USERNAME}: /home/${USERNAME}/.local/
 
-RUN /home/${USERNAME}/.local/flutter/bin/dart pub global activate protoc_plugin
-
 #Install gcloud
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && apt-get install google-cloud-sdk -y

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,5 +38,7 @@
 	// Set any environment variables that you need to
 	"remoteEnv": { 
 		"PATH": "${containerEnv:PATH}:/home/codespace/.local/flutter/bin:/home/codespace/.pub-cache/bin",
-	}
+	},
+
+	"postCreateCommand": "dart pub global activate protoc_plugin && dart pub get"
 }


### PR DESCRIPTION
Closes #14 & Closes #12

Users can now successfully start with a blank devcontainer and run make server and it just works.